### PR TITLE
Upgrade eureka-client dependency

### DIFF
--- a/spring-cloud-netflix-dependencies/pom.xml
+++ b/spring-cloud-netflix-dependencies/pom.xml
@@ -14,7 +14,7 @@
 	<name>spring-cloud-netflix-dependencies</name>
 	<description>Spring Cloud Netflix Dependencies</description>
 	<properties>
-		<eureka.version>1.9.21</eureka.version>
+		<eureka.version>1.9.23</eureka.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
I am trying to upgrade the eureka-client dependency to 1.9.23 from 1.9.21. However, it appear that the upgrade is not a drop-in, given this error below:

```
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'scopedTarget.eurekaClient' defined in class path resource
 [org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration$RefreshableEurekaClientConfiguration.class]: Bean instantiation via factory method failed; 
nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.netflix.discovery.EurekaClient]: Factory method 'eurekaClient' 
threw exception; nested exception is java.lang.IllegalStateException: java.lang.AbstractMethodError: Receiver class 
org.springframework.cloud.netflix.eureka.EurekaClientConfigBean does not define or inherit an implementation of the resolved method 'abstract boolean 
shouldEnforceFetchRegistryAtInit()' of interface com.netflix.discovery.EurekaClientConfig.
```

Looks like the method name is renamed in .23. 